### PR TITLE
perf(mhelton-fw13): bypass LUKS crypto workqueues

### DIFF
--- a/hosts/mhelton-fw13/disko-config.nix
+++ b/hosts/mhelton-fw13/disko-config.nix
@@ -32,6 +32,7 @@
                 passwordFile = "/tmp/secret.key"; # Interactive
                 settings = {
                   allowDiscards = true;
+                  bypassWorkqueues = true;
                 };
                 content = {
                   type = "btrfs";


### PR DESCRIPTION
Open the crypted device with no_read_workqueue and no_write_workqueue so cryptsetup encrypts and decrypts inline instead of handing every bio to the kcryptd worker pool. Under many concurrent processes that pool serialized I/O and left the CPUs idle while tasks stalled waiting on the device. This is an open-time flag applied by the initrd, so it takes effect on the next rebuild and reboot with no change to the on-disk format.