### PR TITLE
feat: add niri and DankMaterialShell, switch r2d2 to them

### DIFF
--- a/home/mhelton/ghostty.nix
+++ b/home/mhelton/ghostty.nix
@@ -6,6 +6,7 @@
     enableZshIntegration = config.programs.zsh.enable;
     package = pkgs.ghostty-git;
     settings = {
+      font-family = "FiraCode Nerd Font Mono";
       window-height = 45;
       window-width = 170;
       shell-integration-features = "ssh-env";

--- a/home/mhelton/graphical.nix
+++ b/home/mhelton/graphical.nix
@@ -6,6 +6,7 @@
 }:
 let
   withPlasma = osConfig.services.desktopManager.plasma6.enable;
+  withNiri = osConfig.programs.niri.enable;
 in
 {
   imports = [
@@ -13,6 +14,9 @@ in
   ]
   ++ lib.optionals withPlasma [
     ./plasma.nix
+  ]
+  ++ lib.optionals withNiri [
+    ./niri.nix
   ];
 
   home.packages =
@@ -55,7 +59,7 @@ in
           desktopName = "1Password";
           comment = "Password manager and secure wallet";
           icon = "1password";
-          exec = "1password %U --silent";
+          exec = "1password${lib.optionalString withNiri " --password-store=gnome-libsecret"} %U --silent";
           terminal = false;
           startupNotify = true;
           startupWMClass = "1Password";

--- a/home/mhelton/graphical.nix
+++ b/home/mhelton/graphical.nix
@@ -46,28 +46,26 @@ in
 
   programs.keychain.enable = lib.mkForce withPlasma;
 
+  xdg.autostart = {
+    enable = true;
+    entries = [
+      "${
+        pkgs.makeDesktopItem {
+          name = "1password";
+          desktopName = "1Password";
+          comment = "Password manager and secure wallet";
+          icon = "1password";
+          exec = "1password %U --silent";
+          terminal = false;
+          startupNotify = true;
+          startupWMClass = "1Password";
+          categories = [ "Office" ];
+        }
+      }/share/applications/1password.desktop"
+    ];
+  };
+
   xdg.configFile = {
-    "autostart/1password.desktop".text = ''
-      [Desktop Entry]
-      Categories=Office;
-      Comment[en_US]=Password manager and secure wallet
-      Comment=Password manager and secure wallet
-      Exec=1password %U --silent
-      GenericName[en_US]=
-      GenericName=
-      Icon=1password
-      MimeType=
-      Name[en_US]=1Password
-      Name=1Password
-      Path=
-      StartupNotify=true
-      StartupWMClass=1Password
-      Terminal=false
-      TerminalOptions=
-      Type=Application
-      X-KDE-SubstituteUID=false
-      X-KDE-Username=
-    '';
     "plex-mpv-shim/mpv.conf".text = ''
       fs=yes
       hwdec=vaapi

--- a/home/mhelton/niri.nix
+++ b/home/mhelton/niri.nix
@@ -1,0 +1,390 @@
+{ lib, pkgs, ... }:
+let
+  dms = args: {
+    spawn = [
+      "dms"
+      "ipc"
+      "call"
+    ]
+    ++ args;
+  };
+
+  locked = action: action // { _props.allow-when-locked = true; };
+
+  titled = title: action: action // { _props.hotkey-overlay-title = title; };
+
+  screenshot = args: {
+    spawn = [
+      "dms"
+      "screenshot"
+    ]
+    ++ args;
+  };
+
+  workspaceBinds = lib.foldl' (
+    acc: n:
+    acc
+    // {
+      "Mod+${toString n}".focus-workspace = n;
+      "Mod+Shift+${toString n}".move-column-to-workspace = n;
+    }
+  ) { } (lib.range 1 9);
+in
+{
+  home.packages = with pkgs; [
+    noto-fonts
+    noto-fonts-color-emoji
+  ];
+
+  fonts.fontconfig.defaultFonts = {
+    monospace = [ "FiraCode Nerd Font Mono" ];
+    sansSerif = [ "Noto Sans" ];
+    serif = [ "Noto Serif" ];
+    emoji = [ "Noto Color Emoji" ];
+  };
+
+  programs.ghostty.settings.window-decoration = "client";
+
+  # electron only picks a secret store for desktops it recognises
+  xdg.desktopEntries = {
+    signal = {
+      name = "Signal";
+      comment = "Private messaging from your desktop";
+      exec = "signal-desktop --password-store=gnome-libsecret %U";
+      icon = "signal-desktop";
+      terminal = false;
+      type = "Application";
+      categories = [
+        "Network"
+        "InstantMessaging"
+        "Chat"
+      ];
+      mimeType = [
+        "x-scheme-handler/sgnl"
+        "x-scheme-handler/signalcaptcha"
+      ];
+      settings.StartupWMClass = "signal";
+    };
+
+    "1password" = {
+      name = "1Password";
+      comment = "Password manager and secure wallet";
+      exec = "1password --password-store=gnome-libsecret %U";
+      icon = "1password";
+      terminal = false;
+      type = "Application";
+      categories = [ "Office" ];
+      mimeType = [ "x-scheme-handler/onepassword" ];
+      settings.StartupWMClass = "1Password";
+    };
+  };
+
+  wayland.windowManager.niri = {
+    enable = true;
+    portalPackage = null;
+    systemd.enable = false;
+
+    extraConfig = ''
+      include optional=true "dms/outputs.kdl"
+      include optional=true "dms/colors.kdl"
+      include optional=true "dms/cursor.kdl"
+    '';
+
+    settings = {
+      prefer-no-csd = { };
+      screenshot-path = "~/Pictures/Screenshots/%Y-%m-%d %H-%M-%S.png";
+      hotkey-overlay.skip-at-startup = { };
+
+      input = {
+        keyboard.numlock = { };
+        touchpad = {
+          tap = { };
+          natural-scroll = { };
+          click-method = "clickfinger";
+        };
+      };
+
+      layout = {
+        gaps = 8;
+        center-focused-column = "never";
+        default-column-width.proportion = 0.5;
+        preset-column-widths._children = [
+          { proportion = 0.33333; }
+          { proportion = 0.5; }
+          { proportion = 0.66667; }
+        ];
+        focus-ring.width = 2;
+      };
+
+      binds = workspaceBinds // {
+        "Mod+O" = {
+          _props.repeat = false;
+          toggle-overview = { };
+        };
+        "Mod+Tab" = {
+          _props.repeat = false;
+          toggle-overview = { };
+        };
+        "Mod+Shift+Slash".show-hotkey-overlay = { };
+
+        "Mod+T" = titled "Open Terminal" { spawn = [ "ghostty" ]; };
+        "Mod+Space" = titled "Application Launcher" (dms [
+          "spotlight"
+          "toggle"
+        ]);
+        "Alt+Space" = titled "Spotlight Bar" (dms [
+          "spotlight-bar"
+          "toggle"
+        ]);
+        "Mod+V" = titled "Clipboard Manager" (dms [
+          "clipboard"
+          "toggle"
+        ]);
+        "Mod+M" = titled "Task Manager" (dms [
+          "processlist"
+          "focusOrToggle"
+        ]);
+        "Ctrl+Alt+Delete" = titled "Task Manager" (dms [
+          "processlist"
+          "focusOrToggle"
+        ]);
+        "Super+X" = titled "Power Menu: Toggle" (dms [
+          "powermenu"
+          "toggle"
+        ]);
+        "Mod+Comma" = titled "Settings" (dms [
+          "settings"
+          "focusOrToggle"
+        ]);
+        "Mod+Y" = titled "Browse Wallpapers" (dms [
+          "dash"
+          "toggle"
+          "wallpaper"
+        ]);
+        "Mod+N" = titled "Notification Center" (dms [
+          "notifications"
+          "toggle"
+        ]);
+        "Mod+Shift+N" = titled "Notepad" (dms [
+          "notepad"
+          "toggle"
+        ]);
+        "Mod+Alt+L" = titled "Lock Screen" (dms [
+          "lock"
+          "lock"
+        ]);
+        "Mod+Shift+E".quit = { };
+
+        "XF86AudioRaiseVolume" = locked (dms [
+          "audio"
+          "increment"
+          "3"
+        ]);
+        "XF86AudioLowerVolume" = locked (dms [
+          "audio"
+          "decrement"
+          "3"
+        ]);
+        "XF86AudioMute" = locked (dms [
+          "audio"
+          "mute"
+        ]);
+        "XF86AudioMicMute" = locked (dms [
+          "audio"
+          "micmute"
+        ]);
+        "XF86AudioPause" = locked (dms [
+          "mpris"
+          "playPause"
+        ]);
+        "XF86AudioPlay" = locked (dms [
+          "mpris"
+          "playPause"
+        ]);
+        "XF86AudioPrev" = locked (dms [
+          "mpris"
+          "previous"
+        ]);
+        "XF86AudioNext" = locked (dms [
+          "mpris"
+          "next"
+        ]);
+        "Ctrl+XF86AudioRaiseVolume" = locked (dms [
+          "mpris"
+          "increment"
+          "3"
+        ]);
+        "Ctrl+XF86AudioLowerVolume" = locked (dms [
+          "mpris"
+          "decrement"
+          "3"
+        ]);
+        "XF86MonBrightnessUp" = locked (dms [
+          "brightness"
+          "increment"
+          "5"
+          ""
+        ]);
+        "XF86MonBrightnessDown" = locked (dms [
+          "brightness"
+          "decrement"
+          "5"
+          ""
+        ]);
+
+        "Mod+Q" = {
+          _props.repeat = false;
+          close-window = { };
+        };
+        "Mod+F".maximize-column = { };
+        "Mod+Shift+F".fullscreen-window = { };
+        "Mod+Shift+T".toggle-window-floating = { };
+        "Mod+Shift+V".switch-focus-between-floating-and-tiling = { };
+        "Mod+W".toggle-column-tabbed-display = { };
+        "Mod+Shift+W" = titled "Create window rule" (dms [
+          "window-rules"
+          "toggle"
+        ]);
+
+        "Mod+Left".focus-column-left = { };
+        "Mod+Down".focus-window-down = { };
+        "Mod+Up".focus-window-up = { };
+        "Mod+Right".focus-column-right = { };
+        "Mod+H".focus-column-left = { };
+        "Mod+J".focus-window-down = { };
+        "Mod+K".focus-window-up = { };
+        "Mod+L".focus-column-right = { };
+
+        "Mod+Shift+Left".move-column-left = { };
+        "Mod+Shift+Down".move-window-down = { };
+        "Mod+Shift+Up".move-window-up = { };
+        "Mod+Shift+Right".move-column-right = { };
+        "Mod+Shift+H".move-column-left = { };
+        "Mod+Shift+J".move-window-down = { };
+        "Mod+Shift+K".move-window-up = { };
+        "Mod+Shift+L".move-column-right = { };
+
+        "Mod+Home".focus-column-first = { };
+        "Mod+End".focus-column-last = { };
+        "Mod+Ctrl+Home".move-column-to-first = { };
+        "Mod+Ctrl+End".move-column-to-last = { };
+
+        "Mod+Ctrl+Left".focus-monitor-left = { };
+        "Mod+Ctrl+Right".focus-monitor-right = { };
+        "Mod+Ctrl+H".focus-monitor-left = { };
+        "Mod+Ctrl+J".focus-monitor-down = { };
+        "Mod+Ctrl+K".focus-monitor-up = { };
+        "Mod+Ctrl+L".focus-monitor-right = { };
+
+        "Mod+Shift+Ctrl+Left".move-column-to-monitor-left = { };
+        "Mod+Shift+Ctrl+Down".move-column-to-monitor-down = { };
+        "Mod+Shift+Ctrl+Up".move-column-to-monitor-up = { };
+        "Mod+Shift+Ctrl+Right".move-column-to-monitor-right = { };
+        "Mod+Shift+Ctrl+H".move-column-to-monitor-left = { };
+        "Mod+Shift+Ctrl+J".move-column-to-monitor-down = { };
+        "Mod+Shift+Ctrl+K".move-column-to-monitor-up = { };
+        "Mod+Shift+Ctrl+L".move-column-to-monitor-right = { };
+
+        "Mod+Page_Down".focus-workspace-down = { };
+        "Mod+Page_Up".focus-workspace-up = { };
+        "Mod+U".focus-workspace-down = { };
+        "Mod+I".focus-workspace-up = { };
+        "Mod+Ctrl+Down".move-column-to-workspace-down = { };
+        "Mod+Ctrl+Up".move-column-to-workspace-up = { };
+        "Mod+Ctrl+U".move-column-to-workspace-down = { };
+        "Mod+Ctrl+I".move-column-to-workspace-up = { };
+        "Ctrl+Shift+R" = titled "Rename Workspace" (dms [
+          "workspace-rename"
+          "open"
+        ]);
+        "Mod+Shift+Page_Down".move-workspace-down = { };
+        "Mod+Shift+Page_Up".move-workspace-up = { };
+        "Mod+Shift+U".move-workspace-down = { };
+        "Mod+Shift+I".move-workspace-up = { };
+
+        "Mod+WheelScrollDown" = {
+          _props.cooldown-ms = 150;
+          focus-workspace-down = { };
+        };
+        "Mod+WheelScrollUp" = {
+          _props.cooldown-ms = 150;
+          focus-workspace-up = { };
+        };
+        "Mod+Ctrl+WheelScrollDown" = {
+          _props.cooldown-ms = 150;
+          move-column-to-workspace-down = { };
+        };
+        "Mod+Ctrl+WheelScrollUp" = {
+          _props.cooldown-ms = 150;
+          move-column-to-workspace-up = { };
+        };
+        "Mod+WheelScrollRight".focus-column-right = { };
+        "Mod+WheelScrollLeft".focus-column-left = { };
+        "Mod+Ctrl+WheelScrollRight".move-column-right = { };
+        "Mod+Ctrl+WheelScrollLeft".move-column-left = { };
+        "Mod+Shift+WheelScrollDown".focus-column-right = { };
+        "Mod+Shift+WheelScrollUp".focus-column-left = { };
+        "Mod+Ctrl+Shift+WheelScrollDown".move-column-right = { };
+        "Mod+Ctrl+Shift+WheelScrollUp".move-column-left = { };
+
+        "Mod+BracketLeft".consume-or-expel-window-left = { };
+        "Mod+BracketRight".consume-or-expel-window-right = { };
+        "Mod+Period".expel-window-from-column = { };
+
+        "Mod+R".switch-preset-column-width = { };
+        "Mod+Shift+R".switch-preset-window-height = { };
+        "Mod+Ctrl+R".reset-window-height = { };
+        "Mod+Ctrl+F".expand-column-to-available-width = { };
+        "Mod+C".center-column = { };
+        "Mod+Ctrl+C".center-visible-columns = { };
+        "Mod+Minus".set-column-width = "-10%";
+        "Mod+Equal".set-column-width = "+10%";
+        "Mod+Shift+Minus".set-window-height = "-10%";
+        "Mod+Shift+Equal".set-window-height = "+10%";
+
+        "Print" = titled "Screenshot: Region" (screenshot [ ]);
+        "Ctrl+Print" = titled "Screenshot: Full Screen" (screenshot [ "full" ]);
+        "Alt+Print" = titled "Screenshot: Window" (screenshot [ "window" ]);
+        "XF86Launch1" = titled "Screenshot: Region" (screenshot [ ]);
+        "Ctrl+XF86Launch1" = titled "Screenshot: Full Screen" (screenshot [ "full" ]);
+        "Alt+XF86Launch1" = titled "Screenshot: Window" (screenshot [ "window" ]);
+
+        "Mod+P" = titled "Cycle Display Profile" {
+          spawn = [
+            "dms"
+            "ipc"
+            "outputs"
+            "cycleProfile"
+          ];
+        };
+        "Mod+Escape" = {
+          _props.allow-inhibiting = false;
+          toggle-keyboard-shortcuts-inhibit = { };
+        };
+        "Mod+Shift+P".power-off-monitors = { };
+      };
+
+      _children = [
+        {
+          window-rule._children = [
+            {
+              match._props = {
+                app-id = "firefox$";
+                title = "^Picture-in-Picture$";
+              };
+            }
+            { open-floating = true; }
+            { default-column-width.fixed = 480; }
+            { default-window-height.fixed = 270; }
+          ];
+        }
+        {
+          window-rule._children = [
+            { match._props.app-id = "^1Password$"; }
+            { block-out-from = "screen-capture"; }
+          ];
+        }
+      ];
+    };
+  };
+}

--- a/hosts/common/niri.nix
+++ b/hosts/common/niri.nix
@@ -1,0 +1,20 @@
+{ config, lib, ... }:
+{
+  programs.niri.enable = true;
+
+  programs.dms-shell.enable = true;
+
+  services.upower.enable = true;
+
+  services.displayManager.sddm.enable = lib.mkForce false;
+
+  # niri-session imports the login shell's environment wholesale
+  systemd.user.services.niri.serviceConfig.UnsetEnvironment = "SHLVL";
+  systemd.user.services.dms.serviceConfig.UnsetEnvironment = "SHLVL";
+
+  services.displayManager.dms-greeter = {
+    enable = true;
+    compositor.name = "niri";
+    configHome = config.users.users.mhelton.home;
+  };
+}

--- a/hosts/r2d2/default.nix
+++ b/hosts/r2d2/default.nix
@@ -22,6 +22,7 @@
     ../common/steam.nix
     ../common/_1password.nix
     ../common/docker.nix
+    ../common/niri.nix
   ];
 
   # Use the systemd-boot EFI boot loader.
@@ -76,20 +77,11 @@
 
   hardware.graphics.enable = true;
 
-  # Plasma
-  services.displayManager.sddm = {
-    enable = true;
-    wayland.enable = true;
-  };
   security.pam.services.login.fprintAuth = false;
-
-  services.displayManager.defaultSession = "plasma";
-  services.desktopManager.plasma6.enable = true;
 
   environment.systemPackages = with pkgs; [
     sbctl
   ];
-  programs.kdeconnect.enable = true;
 
   environment.variables = {
     VDPAU_DRIVER = "radeonsi";


### PR DESCRIPTION
Adds niri and DankMaterialShell as a pair of modules, and switches r2d2 over to them.

## Shape

`hosts/common/niri.nix` turns on the nixpkgs `programs.niri` and `programs.dms-shell` options, swaps sddm for the shell's own greeter, and adds upower, which plasma had been supplying. `home/mhelton/niri.nix` owns `config.kdl` and nothing else, following the split home-manager documents on its hyprland module — the package is left non-null so the generated kdl is validated at build time. `graphical.nix` picks the home module up through a `withNiri` guard mirroring the existing `withPlasma` one, so a host opts in by importing the system module alone.

Binds are transcribed from the file DMS ships and seeds new installs with, rather than from its nix module, which has drifted and is missing several binds. Display, colour and cursor settings are included from the files DMS writes at runtime, so per-machine scaling stays imperative while the rest stays declarative.

## Things plasma was quietly providing

Most of the work here was finding what disappears with plasma6:

- `fonts.packages` and the fontconfig defaults behind them, which is why ghostty resolved its font to whatever the desktop defined. Naming the font it should use fixes a latent bug on every host, so that change is not niri-specific.
- upower, via `services.upower.enable = config.powerManagement.enable`.
- A secret store electron recognises. Electron only picks one for a fixed list of desktops and otherwise stores keys with a hardcoded plaintext password, so signal and 1password are told which backend to use.

## Notes

`niri-session` imports the login shell's environment wholesale, so `SHLVL` ends up in the systemd user environment and every terminal starts a level deep. Unsetting it on the two units that launch applications puts terminals back at level one. Suggested upstream in niri discussion 3734.

The keyring needs nothing extra: greetd's pam stack already substacks login, which carries gnome-keyring, and gcr-ssh-agent follows it. This matches what mhelton-fw13 has been running under gnome.

r2d2 loses kdeconnect, whose indicator is a plasma applet, and the browser integration that went with it.

## Testing

Running on r2d2. Scaling persists across restarts, the keyring unlocks at login, ssh keys survive a logout, and terminals start at shell level one. Signal relinks and 1password reauthenticates once on the switch, since their old keys were encrypted with the plaintext fallback.

`niri validate` runs against the generated config as part of r2d2's build, so a broken bind fails the flake check rather than the session.
