### PR TITLE
feat(home/niri): zoom window rules and screenshot binds

### DIFF
--- a/home/mhelton/niri.nix
+++ b/home/mhelton/niri.nix
@@ -92,7 +92,6 @@ in
 
     settings = {
       prefer-no-csd = { };
-      screenshot-path = "~/Pictures/Screenshots/%Y-%m-%d %H-%M-%S.png";
       hotkey-overlay.skip-at-startup = { };
 
       input = {
@@ -343,6 +342,9 @@ in
         "Mod+Shift+Minus".set-window-height = "-10%";
         "Mod+Shift+Equal".set-window-height = "+10%";
 
+        "Mod+Shift+S" = titled "Screenshot: Region" (screenshot [ ]);
+        "Mod+Ctrl+Shift+S" = titled "Screenshot: Full Screen" (screenshot [ "full" ]);
+        "Mod+Alt+Shift+S" = titled "Screenshot: Window" (screenshot [ "window" ]);
         "Print" = titled "Screenshot: Region" (screenshot [ ]);
         "Ctrl+Print" = titled "Screenshot: Full Screen" (screenshot [ "full" ]);
         "Alt+Print" = titled "Screenshot: Window" (screenshot [ "window" ]);

--- a/home/mhelton/niri.nix
+++ b/home/mhelton/niri.nix
@@ -387,6 +387,48 @@ in
             { block-out-from = "screen-capture"; }
           ];
         }
+        {
+          window-rule._children = [
+            {
+              match._props = {
+                app-id = "^zoom$";
+                title = "^zoom_linux_float_video_window$";
+              };
+            }
+            { open-floating = true; }
+            {
+              default-floating-position._props = {
+                x = 16;
+                y = 16;
+                relative-to = "bottom-right";
+              };
+            }
+          ];
+        }
+        {
+          window-rule._children = [
+            {
+              match._props = {
+                app-id = "^zoom$";
+                title = "^as_toolbar$";
+              };
+            }
+            {
+              match._props = {
+                app-id = "^zoom$";
+                title = "^as_preview$";
+              };
+            }
+            { open-floating = true; }
+            {
+              default-floating-position._props = {
+                x = 16;
+                y = 16;
+                relative-to = "top-right";
+              };
+            }
+          ];
+        }
       ];
     };
   };


### PR DESCRIPTION
Floats the windows zoom opens while sharing, since niri gave each one a column, and parks them out of the way. Adds `Mod+Shift+S` screenshot binds, because DMS's binds assume a print screen key that a mac keyboard layout does not have. The print bindings stay for keyboards that do.