### PR TITLE
fix(home/niri): float zoom windows by exclusion

### DIFF
--- a/home/mhelton/niri/window-rules.nix
+++ b/home/mhelton/niri/window-rules.nix
@@ -23,18 +23,15 @@
       }
       {
         window-rule._children = [
-          {
-            match._props = {
-              app-id = "^zoom$";
-              title = "^zoom_linux_float_video_window$";
-            };
-          }
+          { match._props.app-id = "^zoom$"; }
+          { exclude._props.title = "^Meeting$"; }
+          { exclude._props.title = "^Zoom Workplace"; }
           { open-floating = true; }
           {
             default-floating-position._props = {
               x = 16;
               y = 16;
-              relative-to = "bottom-right";
+              relative-to = "top-right";
             };
           }
         ];
@@ -44,21 +41,14 @@
           {
             match._props = {
               app-id = "^zoom$";
-              title = "^as_toolbar$";
+              title = "^zoom_linux_float_video_window$";
             };
           }
-          {
-            match._props = {
-              app-id = "^zoom$";
-              title = "^as_preview$";
-            };
-          }
-          { open-floating = true; }
           {
             default-floating-position._props = {
               x = 16;
               y = 16;
-              relative-to = "top-right";
+              relative-to = "bottom-right";
             };
           }
         ];


### PR DESCRIPTION
Zoom's helper windows (`as_toolbar`, `as_preview`, `zoom_linux_float_video_window`, annotation and leave-meeting dialogs) vary by client build, so match everything under the `zoom` app-id and exclude the two windows that belong in the layout.

```kdl
window-rule {
	match app-id="^zoom$"
	exclude title="^Meeting$"
	exclude title="^Zoom Workplace"
	open-floating true
	default-floating-position relative-to="top-right" x=16 y=16
}
window-rule {
	match app-id="^zoom$" title="^zoom_linux_float_video_window$"
	default-floating-position relative-to="bottom-right" x=16 y=16
}
```
