### PR TITLE
Switch tomservo to niri

### DIFF
--- a/home/mhelton/ghostty.nix
+++ b/home/mhelton/ghostty.nix
@@ -6,6 +6,7 @@
     enableZshIntegration = config.programs.zsh.enable;
     package = pkgs.ghostty-git;
     settings = {
+      font-family = config.fonts.fontconfig.defaultFonts.monospace;
       window-height = 45;
       window-width = 170;
       shell-integration-features = "ssh-env";

--- a/home/mhelton/niri/default.nix
+++ b/home/mhelton/niri/default.nix
@@ -21,6 +21,21 @@
     emoji = [ "Noto Color Emoji" ];
   };
 
+  gtk = {
+    enable = true;
+    iconTheme = {
+      package = pkgs.adwaita-icon-theme;
+      name = "Adwaita";
+    };
+  };
+
+  home.pointerCursor = {
+    package = pkgs.adwaita-icon-theme;
+    name = "Adwaita";
+    size = 24;
+    gtk.enable = true;
+  };
+
   programs.ghostty.settings.window-decoration = "client";
 
   # electron only picks a secret store for desktops it recognises

--- a/home/mhelton/niri/dms.nix
+++ b/home/mhelton/niri/dms.nix
@@ -1,4 +1,12 @@
-{ inputs, pkgs, ... }:
+{
+  inputs,
+  osConfig,
+  pkgs,
+  ...
+}:
+let
+  withSunshine = osConfig.services.sunshine.enable;
+in
 {
   imports = [
     inputs.dank-material-shell.homeModules.dank-material-shell
@@ -14,7 +22,7 @@
       currentThemeCategory = "dynamic";
 
       acMonitorTimeout = 600;
-      acLockTimeout = 600;
+      acLockTimeout = if withSunshine then 0 else 600;
       acPostLockMonitorTimeout = 30;
       batteryMonitorTimeout = 300;
       batteryLockTimeout = 300;

--- a/hosts/common/sunshine.nix
+++ b/hosts/common/sunshine.nix
@@ -1,0 +1,66 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+let
+  withPlasma = config.services.desktopManager.plasma6.enable;
+  withNiri = config.programs.niri.enable;
+
+  output = "DP-4";
+  nativeMode = "3440x1440@144";
+
+  kscreen-doctor = "${pkgs.kdePackages.libkscreen}/bin/kscreen-doctor";
+  niri = "${config.programs.niri.package}/bin/niri";
+
+  desktop =
+    {
+      name,
+      plasmaMode,
+      niriMode,
+    }:
+    {
+      inherit name;
+      prep-cmd =
+        lib.optional withNiri {
+          do = "${niri} msg output ${output} ${niriMode}";
+          undo = "${niri} msg output ${output} mode auto";
+        }
+        ++ lib.optional withPlasma {
+          do = "${kscreen-doctor} output.${output}.mode.${plasmaMode}";
+          undo = "${kscreen-doctor} output.${output}.mode.${nativeMode}";
+        };
+      exclude-global-prep-cmd = "false";
+      auto-detach = "true";
+    };
+in
+{
+  services.sunshine = {
+    enable = true;
+    capSysAdmin = true;
+    openFirewall = true;
+    applications = {
+      env = {
+        PATH = "$(PATH):$(HOME)/.local/bin";
+      };
+      apps = [
+        (desktop {
+          name = "1440p Desktop";
+          plasmaMode = "2560x1440@60";
+          niriMode = "mode 2560x1440";
+        })
+        (desktop {
+          name = "1080p Desktop";
+          plasmaMode = "1920x1080@60";
+          niriMode = "mode 1920x1080";
+        })
+        (desktop {
+          name = "800p Desktop";
+          plasmaMode = "1280x800@60";
+          niriMode = "custom-mode 1280x800@60";
+        })
+      ];
+    };
+  };
+}

--- a/hosts/tomservo/default.nix
+++ b/hosts/tomservo/default.nix
@@ -1,4 +1,5 @@
 {
+  config,
   pkgs,
   lib,
   ...
@@ -13,6 +14,7 @@
     ../common/docker.nix
     ../common/libvirt.nix
     ../common/mesa-git.nix
+    ../common/niri.nix
   ];
 
   networking.hostName = "tomservo";
@@ -56,15 +58,6 @@
     enable = true;
   };
 
-  # Plasma
-  services.displayManager.sddm = {
-    enable = true;
-    wayland.enable = true;
-  };
-  services.displayManager.defaultSession = "plasma";
-  services.desktopManager.plasma6.enable = true;
-  programs.kdeconnect.enable = true;
-
   services.displayManager.autoLogin.user = "mhelton";
 
   services.avahi = {
@@ -102,8 +95,8 @@
           name = "1440p Desktop";
           prep-cmd = [
             {
-              do = "${pkgs.kdePackages.libkscreen}/bin/kscreen-doctor output.DP-4.mode.2560x1440@60";
-              undo = "${pkgs.kdePackages.libkscreen}/bin/kscreen-doctor output.DP-4.mode.3440x1440@144";
+              do = "${config.programs.niri.package}/bin/niri msg output DP-4 mode 2560x1440";
+              undo = "${config.programs.niri.package}/bin/niri msg output DP-4 mode auto";
             }
           ];
           exclude-global-prep-cmd = "false";
@@ -113,8 +106,8 @@
           name = "1080p Desktop";
           prep-cmd = [
             {
-              do = "${pkgs.kdePackages.libkscreen}/bin/kscreen-doctor output.DP-4.mode.1920x1080@60";
-              undo = "${pkgs.kdePackages.libkscreen}/bin/kscreen-doctor output.DP-4.mode.3440x1440@144";
+              do = "${config.programs.niri.package}/bin/niri msg output DP-4 mode 1920x1080";
+              undo = "${config.programs.niri.package}/bin/niri msg output DP-4 mode auto";
             }
           ];
           exclude-global-prep-cmd = "false";
@@ -124,8 +117,8 @@
           name = "800p Desktop";
           prep-cmd = [
             {
-              do = "${pkgs.kdePackages.libkscreen}/bin/kscreen-doctor output.DP-4.mode.1280x800@60";
-              undo = "${pkgs.kdePackages.libkscreen}/bin/kscreen-doctor output.DP-4.mode.3440x1440@144";
+              do = "${config.programs.niri.package}/bin/niri msg output DP-4 custom-mode 1280x800@60";
+              undo = "${config.programs.niri.package}/bin/niri msg output DP-4 mode auto";
             }
           ];
           exclude-global-prep-cmd = "false";

--- a/hosts/tomservo/default.nix
+++ b/hosts/tomservo/default.nix
@@ -1,5 +1,4 @@
 {
-  config,
   pkgs,
   lib,
   ...
@@ -15,6 +14,7 @@
     ../common/libvirt.nix
     ../common/mesa-git.nix
     ../common/niri.nix
+    ../common/sunshine.nix
   ];
 
   networking.hostName = "tomservo";
@@ -80,52 +80,6 @@
   services.printing = {
     enable = true;
     drivers = with pkgs; [ gutenprint ];
-  };
-
-  services.sunshine = {
-    enable = true;
-    capSysAdmin = true;
-    openFirewall = true;
-    applications = {
-      env = {
-        PATH = "$(PATH):$(HOME)/.local/bin";
-      };
-      apps = [
-        {
-          name = "1440p Desktop";
-          prep-cmd = [
-            {
-              do = "${config.programs.niri.package}/bin/niri msg output DP-4 mode 2560x1440";
-              undo = "${config.programs.niri.package}/bin/niri msg output DP-4 mode auto";
-            }
-          ];
-          exclude-global-prep-cmd = "false";
-          auto-detach = "true";
-        }
-        {
-          name = "1080p Desktop";
-          prep-cmd = [
-            {
-              do = "${config.programs.niri.package}/bin/niri msg output DP-4 mode 1920x1080";
-              undo = "${config.programs.niri.package}/bin/niri msg output DP-4 mode auto";
-            }
-          ];
-          exclude-global-prep-cmd = "false";
-          auto-detach = "true";
-        }
-        {
-          name = "800p Desktop";
-          prep-cmd = [
-            {
-              do = "${config.programs.niri.package}/bin/niri msg output DP-4 custom-mode 1280x800@60";
-              undo = "${config.programs.niri.package}/bin/niri msg output DP-4 mode auto";
-            }
-          ];
-          exclude-global-prep-cmd = "false";
-          auto-detach = "true";
-        }
-      ];
-    };
   };
 
   networking.interfaces.enp6s0.wakeOnLan.enable = true;

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -33,6 +33,16 @@ let
         patches = [ ];
       });
 
+      # without this the xwayland screen size lags behind output mode changes
+      xwayland-satellite = prev.xwayland-satellite.overrideAttrs (old: {
+        patches = (old.patches or [ ]) ++ [
+          (prev.fetchpatch {
+            url = "https://github.com/devusb/xwayland-satellite/commit/6df3012.patch";
+            hash = "sha256-Icc+VFPBKkrhso3cIZiUiul7Qvna4ITNleDanmWXsj4=";
+          })
+        ];
+      });
+
       openldap = prev.openldap.overrideAttrs {
         doCheck = !prev.stdenv.hostPlatform.isi686;
       };


### PR DESCRIPTION
Moves tomservo from plasma to niri, with the supporting home-manager and overlay changes.

- `hosts/tomservo`: drop sddm/plasma6/kdeconnect, import `common/niri.nix`
- `hosts/common/sunshine.nix`: sunshine split out of the host, with prep-cmds that select `kscreen-doctor` or `niri msg` depending on which desktop the host enables — the plasma commands were lost in the switch and are restored here
- `home/niri`: skip idle locking on hosts running sunshine, install an Adwaita icon and cursor theme
- `overlays`: patch xwayland-satellite logical size reporting
- `home/ghostty`: name the fallback font alongside the first

Both branches of the sunshine conditional evaluate to the same commands as before the switch, and `nixosConfigurations.tomservo` builds.