### PR TITLE
Leave bluetooth off at boot on portable hosts

### DIFF
--- a/hosts/bob/default.nix
+++ b/hosts/bob/default.nix
@@ -39,6 +39,7 @@
   };
   hardware.bluetooth = {
     enable = true;
+    powerOnBoot = false;
   };
 
   fileSystems."/mnt/sdcard" = {

--- a/hosts/mhelton-fw13/default.nix
+++ b/hosts/mhelton-fw13/default.nix
@@ -41,7 +41,10 @@
     enable = true;
   };
 
-  hardware.bluetooth.enable = true;
+  hardware.bluetooth = {
+    enable = true;
+    powerOnBoot = false;
+  };
   hardware.sensor.iio.enable = false;
   hardware.enableAllFirmware = true;
 

--- a/hosts/r2d2/default.nix
+++ b/hosts/r2d2/default.nix
@@ -48,7 +48,10 @@
     wifi.backend = "iwd";
   };
 
-  hardware.bluetooth.enable = true;
+  hardware.bluetooth = {
+    enable = true;
+    powerOnBoot = false;
+  };
   hardware.sensor.iio.enable = false;
   hardware.enableAllFirmware = true;
 


### PR DESCRIPTION
Sets `hardware.bluetooth.powerOnBoot = false` on bob, r2d2 and mhelton-fw13.

`powerOnBoot` writes `Policy.AutoEnable` into `main.conf`, which BlueZ documents as "enable all controllers when they are found ... adapters present on start as well as adapters that are plugged in later on." Since `store_adapter_info` (`src/adapter.c:565`) only persists `PairableTimeout`, `Discoverable`, `DiscoverableTimeout` and `Alias` — never `Powered` — there is no last-state to restore, so this is the only way to have them come up off.

durandal keeps `AutoEnable=true`; tomservo has no bluetooth configured.

Verified by reading each host's generated `main.conf`, and all three hosts build.