### PR TITLE
feat(durandal): boot into plasma-bigscreen

### DIFF
--- a/hosts/durandal/bigscreen.nix
+++ b/hosts/durandal/bigscreen.nix
@@ -1,7 +1,5 @@
 { pkgs, ... }:
 let
-  # the homescreen containment imports org.kde.kdeconnect, which upstream leaves off
-  # the session wrapper's qml import path
   plasma-bigscreen = pkgs.kdePackages.plasma-bigscreen.overrideAttrs (old: {
     buildInputs = (old.buildInputs or [ ]) ++ [ pkgs.kdePackages.kdeconnect-kde ];
     preFixup = (old.preFixup or "") + ''
@@ -10,7 +8,6 @@ let
   });
 in
 {
-  # the session script sources plasma-bigscreen-common-env by bare name
   environment.systemPackages = [ plasma-bigscreen ];
 
   services.displayManager = {
@@ -18,7 +15,6 @@ in
     defaultSession = "plasma-bigscreen-wayland";
   };
 
-  # plasma6 sets this to plasma-workspace alone with mkDefault
   xdg.portal.configPackages = [
     pkgs.kdePackages.plasma-workspace
     plasma-bigscreen

--- a/hosts/durandal/bigscreen.nix
+++ b/hosts/durandal/bigscreen.nix
@@ -1,0 +1,26 @@
+{ pkgs, ... }:
+let
+  # the homescreen containment imports org.kde.kdeconnect, which upstream leaves off
+  # the session wrapper's qml import path
+  plasma-bigscreen = pkgs.kdePackages.plasma-bigscreen.overrideAttrs (old: {
+    buildInputs = (old.buildInputs or [ ]) ++ [ pkgs.kdePackages.kdeconnect-kde ];
+    preFixup = (old.preFixup or "") + ''
+      wrapQtApp $out/bin/plasma-bigscreen-wayland
+    '';
+  });
+in
+{
+  # the session script sources plasma-bigscreen-common-env by bare name
+  environment.systemPackages = [ plasma-bigscreen ];
+
+  services.displayManager = {
+    sessionPackages = [ plasma-bigscreen ];
+    defaultSession = "plasma-bigscreen-wayland";
+  };
+
+  # plasma6 sets this to plasma-workspace alone with mkDefault
+  xdg.portal.configPackages = [
+    pkgs.kdePackages.plasma-workspace
+    plasma-bigscreen
+  ];
+}

--- a/hosts/durandal/default.nix
+++ b/hosts/durandal/default.nix
@@ -10,6 +10,7 @@
     ../common/steam.nix
     ../common/_1password.nix
     ./wake.nix
+    ./bigscreen.nix
   ];
 
   # Use the systemd-boot EFI boot loader.
@@ -56,7 +57,6 @@
     wayland.enable = true;
   };
   services.displayManager = {
-    defaultSession = "plasma";
     autoLogin = {
       enable = true;
       user = "mhelton";


### PR DESCRIPTION
Registers the bigscreen wayland session as the autologin default on durandal. Plasma stays selectable from the greeter.

`kdePackages.plasma-bigscreen` omits `kdeconnect-kde`, so the homescreen containment's `org.kde.kdeconnect` import is missing from the session wrapper's QML path. Adding it as a build input and re-wrapping `plasma-bigscreen-wayland` supplies it — the wrap is explicit because `wrapQtAppsHook` skips shell scripts.

Verified against the built toplevel: SDDM autologin and default session both resolve to `plasma-bigscreen-wayland.desktop`, greeter still offers `plasma` and `plasmax11`, wrapper carries the kdeconnect QML path. Not yet deployed.