### PR TITLE
feat(hosts): add tether to r2d2 and mhelton-fw13

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1238,6 +1238,7 @@
         "plasma-manager": "plasma-manager",
         "sops-nix": "sops-nix",
         "superpowers": "superpowers",
+        "tether": "tether",
         "treefmt-nix": "treefmt-nix_3",
         "utils": "utils",
         "wolweb-cli": "wolweb-cli"
@@ -1393,6 +1394,26 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default",
+        "type": "github"
+      }
+    },
+    "tether": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1788707309,
+        "narHash": "sha256-ngf2EvkEM5XcuwWm5fYXIGMnOzMDoMvaxU0CGE5caAM=",
+        "owner": "zackb",
+        "repo": "tether",
+        "rev": "ec6d731a25ec675e641d7abbc4364d329847ea7a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "zackb",
+        "repo": "tether",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -115,6 +115,10 @@
 
     # gog-nix
     gog-nix.url = "github:xiro-codes/gog.nix";
+
+    # tether
+    tether.url = "github:zackb/tether";
+    tether.inputs.nixpkgs.follows = "nixpkgs";
   };
 
   outputs =

--- a/hosts/common/tether.nix
+++ b/hosts/common/tether.nix
@@ -1,0 +1,15 @@
+{ inputs, ... }:
+{
+  imports = [
+    inputs.tether.nixosModules.tether
+  ];
+
+  programs.tether = {
+    enable = true;
+    wifi = {
+      enable = true;
+      openFirewall = true;
+    };
+    bluetooth.enable = true;
+  };
+}

--- a/hosts/mhelton-fw13/default.nix
+++ b/hosts/mhelton-fw13/default.nix
@@ -42,10 +42,7 @@
     enable = true;
   };
 
-  hardware.bluetooth = {
-    enable = true;
-    powerOnBoot = false;
-  };
+  hardware.bluetooth.enable = true;
   hardware.sensor.iio.enable = false;
   hardware.enableAllFirmware = true;
 

--- a/hosts/mhelton-fw13/default.nix
+++ b/hosts/mhelton-fw13/default.nix
@@ -18,6 +18,7 @@
     ../common/_1password.nix
     ../common/docker.nix
     ../common/niri.nix
+    ../common/tether.nix
   ];
 
   boot.loader.systemd-boot.enable = lib.mkForce false;
@@ -89,7 +90,6 @@
     drivers = with pkgs; [ gutenprint ];
   };
 
-  services.avahi.enable = lib.mkForce false;
   programs.steam.remotePlay.openFirewall = lib.mkForce false;
   programs.steam.dedicatedServer.openFirewall = lib.mkForce false;
 

--- a/hosts/r2d2/default.nix
+++ b/hosts/r2d2/default.nix
@@ -49,10 +49,7 @@
     wifi.backend = "iwd";
   };
 
-  hardware.bluetooth = {
-    enable = true;
-    powerOnBoot = false;
-  };
+  hardware.bluetooth.enable = true;
   hardware.sensor.iio.enable = false;
   hardware.enableAllFirmware = true;
 

--- a/hosts/r2d2/default.nix
+++ b/hosts/r2d2/default.nix
@@ -23,6 +23,7 @@
     ../common/_1password.nix
     ../common/docker.nix
     ../common/niri.nix
+    ../common/tether.nix
   ];
 
   # Use the systemd-boot EFI boot loader.


### PR DESCRIPTION
Adds [tether](https://github.com/zackb/tether) via its NixOS module, enabled through a shared `hosts/common/tether.nix` on both Framework laptops.

Wifi (with the mDNS/TCP firewall ports) and bluetooth are both on. mhelton-fw13 had avahi forced off, which tether's wifi discovery needs, so that line is dropped. Both hosts also go back to powering the bluetooth adapter at boot, since the class of device unit and the messages/notification path need a live adapter.

`nix build .#checks.x86_64-linux.nixos-r2d2 .#checks.x86_64-linux.nixos-mhelton-fw13` passes.