### PR TITLE
feat(overlays): override libcec to 8.1.7

### DIFF
--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -26,6 +26,15 @@ let
         '';
       });
 
+      # 8.x detects CEC device node removal and no longer pins /dev/cec0: https://github.com/Pulse-Eight/libcec/issues/668
+      libcec = prev.libcec.overrideAttrs (old: rec {
+        version = "8.1.7";
+        src = old.src.override {
+          rev = "libcec-${version}";
+          sha256 = "sha256-teh4w6pDn0HJ9W0FnqhnMYFBd6JxgK9QYfVqYHXviiI=";
+        };
+      });
+
       chiaki-ng = prev.chiaki-ng.overrideAttrs (old: {
         version = "1.10.0-unstable-2026-07-04";
         src = old.src.override {


### PR DESCRIPTION
nixpkgs is still on libcec 7.1.1, which never releases the fd when the kernel recreates the CEC node — pinning the old minor so it reappears as /dev/cec1, where libcec can't find it. That leaves the Bigscreen remote dead after the TV or the box sleeps until the input handler is restarted by hand.