### PR TITLE
feat(durandal): restart the bigscreen input handler when CEC returns

### DIFF
--- a/hosts/durandal/bigscreen.nix
+++ b/hosts/durandal/bigscreen.nix
@@ -6,6 +6,12 @@ let
       wrapQtApp $out/bin/plasma-bigscreen-wayland
     '';
   });
+
+  user = "mhelton";
+  machinectl = pkgs.lib.getExe' pkgs.systemd "machinectl";
+  systemd-run = pkgs.lib.getExe' pkgs.systemd "systemd-run";
+  pkill = pkgs.lib.getExe' pkgs.procps "pkill";
+  inputhandler = "/run/current-system/sw/bin/plasma-bigscreen-inputhandler";
 in
 {
   environment.systemPackages = [ plasma-bigscreen ];
@@ -19,4 +25,22 @@ in
     pkgs.kdePackages.plasma-workspace
     plasma-bigscreen
   ];
+
+  services.udev.extraRules = ''
+    SUBSYSTEM=="cec", KERNEL=="cec0", ACTION=="add", TAG+="systemd", ENV{SYSTEMD_WANTS}="bigscreen-cec-reattach.service"
+  '';
+
+  systemd.services.bigscreen-cec-reattach = {
+    description = "Reattach the Plasma Bigscreen input handler to the CEC device";
+    unitConfig = {
+      BindsTo = "dev-cec0.device";
+      After = "dev-cec0.device";
+    };
+    serviceConfig = {
+      Type = "oneshot";
+      RemainAfterExit = "yes";
+      ExecStartPre = "-${pkill} -f plasma-bigscreen-inputhandler";
+      ExecStart = "-${machinectl} shell ${user}@ ${systemd-run} --user --unit=bigscreen-inputhandler --collect --setenv=QT_QPA_PLATFORM=offscreen ${inputhandler}";
+    };
+  };
 }


### PR DESCRIPTION
libcec 8.1.7 now releases the fd and raises CEC_ALERT_CONNECTION_LOST when the kernel recreates the CEC node, so the node reliably comes back as /dev/cec0 instead of drifting to cec1. Plasma Bigscreen ignores that alert and never re-runs adapter detection, so the TV remote stays dead after a power cycle or a suspend until the handler is restarted by hand. This binds a oneshot to dev-cec0.device and relaunches the handler in the user session when the node reappears.