### PR TITLE
refactor(durandal): drop BindsTo from the CEC reattach unit

### DIFF
--- a/hosts/durandal/bigscreen.nix
+++ b/hosts/durandal/bigscreen.nix
@@ -8,10 +8,6 @@ let
   });
 
   user = "mhelton";
-  machinectl = pkgs.lib.getExe' pkgs.systemd "machinectl";
-  systemd-run = pkgs.lib.getExe' pkgs.systemd "systemd-run";
-  pkill = pkgs.lib.getExe' pkgs.procps "pkill";
-  inputhandler = "/run/current-system/sw/bin/plasma-bigscreen-inputhandler";
 in
 {
   environment.systemPackages = [ plasma-bigscreen ];
@@ -32,15 +28,9 @@ in
 
   systemd.services.bigscreen-cec-reattach = {
     description = "Reattach the Plasma Bigscreen input handler to the CEC device";
-    unitConfig = {
-      BindsTo = "dev-cec0.device";
-      After = "dev-cec0.device";
-    };
     serviceConfig = {
       Type = "oneshot";
-      RemainAfterExit = "yes";
-      ExecStartPre = "-${pkill} -f plasma-bigscreen-inputhandler";
-      ExecStart = "-${machinectl} shell ${user}@ ${systemd-run} --user --unit=bigscreen-inputhandler --collect --setenv=QT_QPA_PLATFORM=offscreen ${inputhandler}";
+      ExecStart = "${pkgs.lib.getExe' pkgs.systemd "machinectl"} shell ${user}@ ${pkgs.lib.getExe' pkgs.systemd "systemctl"} --user restart bigscreen-inputhandler";
     };
   };
 


### PR DESCRIPTION
RemainAfterExit pins the oneshot active after it runs, so BindsTo=dev-cec0.device is needed purely to deactivate it before the next udev add can re-trigger it. Without RemainAfterExit the unit goes inactive on its own and SYSTEMD_WANTS starts it again directly, which drops two moving parts and the stop/start ordering on a fast TV off/on. The udev rule is unchanged and still supplies both the systemd tag and the activation.