### PR TITLE
feat(durandal): restart the bigscreen input handler after resume

### DIFF
--- a/hosts/durandal/bigscreen.nix
+++ b/hosts/durandal/bigscreen.nix
@@ -43,4 +43,20 @@ in
       ExecStart = "-${machinectl} shell ${user}@ ${systemd-run} --user --unit=bigscreen-inputhandler --collect --setenv=QT_QPA_PLATFORM=offscreen ${inputhandler}";
     };
   };
+
+  systemd.services.bigscreen-cec-resume = {
+    description = "Restart the Plasma Bigscreen input handler after resume";
+    unitConfig = {
+      DefaultDependencies = "no";
+      StopWhenUnneeded = "yes";
+      Before = "sleep.target";
+    };
+    serviceConfig = {
+      Type = "oneshot";
+      RemainAfterExit = "yes";
+
+      ExecStop = "${pkgs.lib.getExe' pkgs.systemd "machinectl"} shell ${user}@ ${pkgs.lib.getExe' pkgs.systemd "systemctl"} --user restart bigscreen-inputhandler";
+    };
+    wantedBy = [ "sleep.target" ];
+  };
 }


### PR DESCRIPTION
Suspend leaves libcec's connection dead but the CEC device node intact, so nothing churns on resume and the udev-triggered reattach unit never fires. Bigscreen then declines to recover on its own, logging "Hotplug timeout - skipping (adapter already open)" — its guard checks only that the adapter pointer is non-null, not that it still works. The remote stays dead until the node happens to be recreated, which depends on whether the TV drops HPD and is therefore unreliable.

Mirrors restart-wireplumber in wake.nix: the unit goes active before sleep.target and its ExecStop fires on resume, bouncing the handler so there is no stale adapter for the guard to trip on.